### PR TITLE
remove()

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,6 +120,12 @@ Sorted.prototype.findIndex = function (x, start, end) {
     return k;
 };
 
+Sorted.prototype.remove = function(x, start, end) {
+  var i = this.findIndex(x, start, end);
+  if (i != -1 ) this.splice(i, 1);
+  return this.elements;
+};
+
 Sorted.prototype.indexOf = function (x) {
     var i = this.findIndex(x);
     return this.elements[i] === x ? i : -1;

--- a/readme.markdown
+++ b/readme.markdown
@@ -108,6 +108,12 @@ Remove `len` elements starting at index `i`.
 Any additional arguments will be pushed to the structure maintaining the sorted
 order.
 
+## s.remove(x, start=0, end=s.length)
+
+Remove the first occurance of element starting at index `start`, and
+ending at `end` using a binary search.
+
+
 ## s.findIndex(x, start=0, end=s.length)
 
 Search for the index of the value `x` starting at index `start` and ending at

--- a/test/s.js
+++ b/test/s.js
@@ -108,6 +108,22 @@ test('slice', function (assert) {
     assert.end();
 });
 
+test('remove', function(assert) {
+    var xs = [ 1, 2, 3, 4, 5, 6, 7 ];
+    var s = sorted(xs);
+
+    var start_length = s.length;
+    s.remove(1);
+    assert.equal(s.length, start_length - 1);
+    assert.equal(s.indexOf(1), - 1);
+
+    assert.notEqual(s.indexOf(6), -1);
+    s.remove(6);
+    assert.equal(s.indexOf(6), -1);
+
+    assert.end();
+});
+
 test('map', function (assert) {
     var xs = [ 1, 1, 2, 3, 5, 8, 13 ];
     var s = sorted(xs);


### PR DESCRIPTION
Pardon my ignorance, but `remove()` is something I'm used to from Python, which JavaScript arrays don't have and I rarely see in the wild. Is there any reasons for that?